### PR TITLE
Changed "import Image" to "from PIL import Image" to allow people using ...

### DIFF
--- a/addpattern.py
+++ b/addpattern.py
@@ -19,7 +19,7 @@
 
 import sys
 import brother
-import Image
+from PIL import Image
 import array
 
 TheImage = None

--- a/app/tkapp/Config.py
+++ b/app/tkapp/Config.py
@@ -2,14 +2,20 @@
 
 class Config:
     def __init__(self):
-        config = ConfigParser.ConfigParser({'simulateEmulator':'False'},
-                                           allow_no_value=True)
 
-        with open('config.cfg') as cfgFile:
+        try:
+            cfgFile = open('config.cfg','rb')
+            config = ConfigParser.ConfigParser({'simulateEmulator':'False'},
+                                               allow_no_value=True)
             config.readfp(cfgFile)
             self.imgdir = config.get('UserPrefs','imgdir')
             self.datFile = config.get('UserPrefs','datFile')
             self.device = config.get('UserPrefs','device')
             self.simulateEmulator = config.get('UserPrefs','simulateEmulator')
+        except (OSError, IOError):
+            self.imgdir = ""
+            self.datFile = ""
+            self.device = ""
+            self.simulateEmulator = False
 
         cfgFile.close()

--- a/app/tkapp/Config.py
+++ b/app/tkapp/Config.py
@@ -1,12 +1,15 @@
-﻿import os
+﻿import ConfigParser
 
 class Config:
     def __init__(self):
-        self.imgdir = "img";
-        if os.sys.platform == 'win32':
-            self.device = "com34"
-#            self.datFile = 'C:/Documents and Settings/ondro/VirtualBox shared folder/knitting/knitting_machine-master/img/zaloha vzory stroj python.dat'
-            self.datFile = 'C:/Documents and Settings/ondro/VirtualBox shared folder/knitting/knitting_machine-master/file-06.dat'
-            self.simulateEmulator = True
-        else:
-            self.device = "/dev/ttyUSB0"
+        config = ConfigParser.ConfigParser({'simulateEmulator':'False'},
+                                           allow_no_value=True)
+
+        with open('config.cfg') as cfgFile:
+            config.readfp(cfgFile)
+            self.imgdir = config.get('UserPrefs','imgdir')
+            self.datFile = config.get('UserPrefs','datFile')
+            self.device = config.get('UserPrefs','device')
+            self.simulateEmulator = config.get('UserPrefs','simulateEmulator')
+
+        cfgFile.close()

--- a/app/tkapp/KnittingApp.py
+++ b/app/tkapp/KnittingApp.py
@@ -12,7 +12,7 @@ import Tkinter
 import tkFileDialog
 import os
 import os.path
-import Image
+from PIL import Image
 import itertools
 
 class KnittingApp(Tkinter.Tk):

--- a/insertpattern.py
+++ b/insertpattern.py
@@ -19,11 +19,12 @@
 
 import sys
 import brother
-import Image
+from PIL import Image
 import array
 
 # import convenience functions from brother module
-from brother import roundeven, roundfour, roundeight, nibblesPerRow, bytesPerPattern, bytesForMemo, methodWithPointers
+from brother import roundeven, roundfour, roundeight, nibblesPerRow
+from brother import bytesPerPattern, bytesForMemo, methodWithPointers
 
 TheImage = None
 
@@ -34,7 +35,7 @@ class PatternInserter:
         self.printInfoCallback = self.printInfo
         self.printErrorCallback = self.printError
         self.printPatternCallback = self.printPattern
-        
+
     def printInfo(self, printMsg):
         print printMsg
 


### PR DESCRIPTION
...Pillow to not need to modify the code.

Rewrote the Config module to use the built-in ConfigParser and added a config file. This will only work with Python 2. People with v3 will need to either change code to "configparser" or run a script to make that change.